### PR TITLE
[Bugfix] Coloring qualifier with string label.

### DIFF
--- a/syntaxes/codev.tmLanguage.json
+++ b/syntaxes/codev.tmLanguage.json
@@ -210,7 +210,7 @@
 				},
 				{
 					"comment": "qualifier with string label",
-					"match": "\\s((?i)[abefgijlqrstuwz])((\".*\")|('.*'))",
+					"match": "\\s((?i)[abefgijlqrstuwz])((\".*?\")|('.*?'))",
 					"captures":{
 						"1":{
 							"name": "support.type.qualifier.codev"


### PR DESCRIPTION
There was a small bug with syntactic coloration. Sometimes, what's inside two strings on the same line was also marked as a string.
Before:

<img width="584" alt="with_bug" src="https://user-images.githubusercontent.com/60904290/130680107-476e9e90-cdcd-4bac-84c3-e64dbad70988.png">

After the bugfix:

<img width="573" alt="without_bug" src="https://user-images.githubusercontent.com/60904290/130680097-cadf8834-fc5b-49db-a806-a9e5525a5c9b.png">

I hope it will help!